### PR TITLE
Add auto_mode_enabled variable and use remote iam-roles module

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -9,9 +9,9 @@ resource "kubernetes_ingress_class_v1" "default" {
   }
 
   spec {
-    controller = "ingress.k8s.aws/alb"
+    controller = var.auto_mode_enabled ? "eks.amazonaws.com/alb" : "ingress.k8s.aws/alb"
     parameters {
-      api_group = "elbv2.k8s.aws"
+      api_group = var.auto_mode_enabled ? "eks.amazonaws.com" : "elbv2.k8s.aws"
       kind      = "IngressClassParams"
       name      = var.class_name
     }
@@ -23,7 +23,7 @@ resource "kubernetes_ingress_class_v1" "default" {
 resource "kubernetes_manifest" "alb_controller_class_params" {
   count = module.this.enabled ? 1 : 0
   manifest = {
-    apiVersion = "elbv2.k8s.aws/v1beta1"
+    apiVersion = var.auto_mode_enabled ? "eks.amazonaws.com/v1" : "elbv2.k8s.aws/v1beta1"
     kind       = "IngressClassParams"
     metadata = {
       name = var.class_name

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -14,6 +14,6 @@ provider "aws" {
 }
 
 module "iam_roles" {
-  source  = "../../account-map/modules/iam-roles"
+  source  = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.537.2"
   context = module.this.context
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.eks_component_name
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -63,3 +63,18 @@ variable "additional_tags" {
   description = "Additional tags to apply to the ingress load balancer."
   default     = {}
 }
+
+variable "auto_mode_enabled" {
+  type        = bool
+  description = <<-EOT
+    Enable EKS Auto Mode. When enabled, AWS manages compute (via managed Karpenter),
+    networking (elastic load balancing), and storage (EBS block storage) for the cluster.
+    Requires Kubernetes 1.29+ and AWS provider >= 5.79.0.
+    Cannot be used with `karpenter_iam_role_enabled = true` (Auto Mode includes managed Karpenter).
+    When enabled, the addons `vpc-cni`, `kube-proxy`, `coredns`, and `aws-ebs-csi-driver` are
+    managed by Auto Mode and should be removed from the `addons` variable (or use `auto_mode_upgrade`
+    for brownfield migration).
+    EOT
+  default     = false
+  nullable    = false
+}


### PR DESCRIPTION
## What

* Added `auto_mode_enabled` variable to support EKS Auto Mode configuration
* Switched `iam-roles` module source from local path (`../../account-map/modules/iam-roles`) to a pinned remote reference (`github.com/cloudposse-terraform-components/aws-account-map//src/modules/iam-roles?ref=v1.537.2`)

## Why

* EKS Auto Mode is a newer EKS feature where AWS manages compute, networking, and storage for the cluster. This variable prepares the component for Auto Mode support.
* Using a remote module reference for `iam-roles` makes the component self-contained and deployable without depending on a local `account-map` component checkout.

## References

* Requires Kubernetes 1.29+ and AWS provider >= 5.79.0 when Auto Mode is enabled
* Not compatible with `karpenter_iam_role_enabled = true` (Auto Mode includes managed Karpenter)