### PR TITLE
Fix variable name for EKS Auto Mode

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -9,9 +9,9 @@ resource "kubernetes_ingress_class_v1" "default" {
   }
 
   spec {
-    controller = var.auto_mode_enabled ? "eks.amazonaws.com/alb" : "ingress.k8s.aws/alb"
+    controller = var.eks_auto_mode_enabled ? "eks.amazonaws.com/alb" : "ingress.k8s.aws/alb"
     parameters {
-      api_group = var.auto_mode_enabled ? "eks.amazonaws.com" : "elbv2.k8s.aws"
+      api_group = var.eks_auto_mode_enabled ? "eks.amazonaws.com" : "elbv2.k8s.aws"
       kind      = "IngressClassParams"
       name      = var.class_name
     }
@@ -23,7 +23,7 @@ resource "kubernetes_ingress_class_v1" "default" {
 resource "kubernetes_manifest" "alb_controller_class_params" {
   count = module.this.enabled ? 1 : 0
   manifest = {
-    apiVersion = var.auto_mode_enabled ? "eks.amazonaws.com/v1" : "elbv2.k8s.aws/v1beta1"
+    apiVersion = var.eks_auto_mode_enabled ? "eks.amazonaws.com/v1" : "elbv2.k8s.aws/v1beta1"
     kind       = "IngressClassParams"
     metadata = {
       name = var.class_name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -64,17 +64,9 @@ variable "additional_tags" {
   default     = {}
 }
 
-variable "auto_mode_enabled" {
+variable "eks_auto_mode_enabled" {
   type        = bool
-  description = <<-EOT
-    Enable EKS Auto Mode. When enabled, AWS manages compute (via managed Karpenter),
-    networking (elastic load balancing), and storage (EBS block storage) for the cluster.
-    Requires Kubernetes 1.29+ and AWS provider >= 5.79.0.
-    Cannot be used with `karpenter_iam_role_enabled = true` (Auto Mode includes managed Karpenter).
-    When enabled, the addons `vpc-cni`, `kube-proxy`, `coredns`, and `aws-ebs-csi-driver` are
-    managed by Auto Mode and should be removed from the `addons` variable (or use `auto_mode_upgrade`
-    for brownfield migration).
-    EOT
+  description = "Set to true if the EKS cluster has Auto Mode compute enabled. Changes the API to `eks.amazonaws.com/` for Auto Mode compatibility."
   default     = false
   nullable    = false
 }


### PR DESCRIPTION
## what

* Renamed `auto_mode_enabled` variable to `eks_auto_mode_enabled` for consistency with the upstream `eks/cluster` component
* Fixed a missed variable reference in `main.tf` that still used the old name
* Simplified the variable description to focus on what it actually controls in this component

## why

* The variable was introduced in #60 as `auto_mode_enabled`, but the upstream `eks/cluster` component uses `eks_auto_mode_enabled` — aligning the names avoids confusion when configuring stacks
* The previous description contained details about EKS Auto Mode that are relevant to the cluster component, not this ingress class component

## references

* Follow-up fix to #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed an infrastructure configuration variable to eks_auto_mode_enabled for clearer intent and consistency; related deployment logic updated to use the new name across networking and load‑balancer configuration.

* **Documentation**
  * Updated the variable description to clearly state it enables EKS Auto Mode compute and that enabling it switches API compatibility to the EKS Auto Mode API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->