### PR TITLE
chore: migrate Renovate base preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- Migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- Preserve the existing `prConcurrentLimit` setting

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

I did not run `atmos test run` because `AGENTS.md` notes the Terratest suite deploys/destroys AWS resources and may incur AWS costs; this PR only changes Renovate configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation tool configuration to use recommended settings instead of base configuration, improving consistency with best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->